### PR TITLE
Add install make target

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ lstbt is present in the ./lib subdirectory of the software.
 Steps:<br>
 1. `cd ./lib`
 2. `make`
+3. `make install`
 
-## Uninstalling lstbt and cleaning up the build
+## cleaning up the build
 
 Steps:<br>
 1. `cd ./lib`
 2. `make clean`
 
 Note: The library installs itself in the /usr/bin filesystem path, hence pertinent permissions are required for the user to alter it.
+Note 2: It is not necessary to install lstbt for testing it.
 
 ## TBT/USB4 user-space functionalities
 This software serves as the first prefatory abstraction of various functionalities of the TBT/USB4 subsystem a user can

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -27,3 +27,4 @@ $(LIBTBT_EXEC): $(O_FILES)
 clean:
 	-$(RM) $(LIBTBT_EXEC) $(O_FILES)
 
+.PHONY: all clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,9 +5,12 @@
 # Copyright (C) 2023 Rajat Khandelwal <rajat.khandelwal@intel.com>
 # Copyright (C) 2023 Intel Corporation
 
-LIBTBT_EXEC = /usr/bin/lstbt
+INSTALL_PATH=/usr/bin
+
+LIBTBT_EXEC = lstbt
 
 CC = gcc
+INSTALL = install
 RM = rm -f
 
 DEBUG_FLAGS = -g
@@ -24,7 +27,14 @@ all: $(LIBTBT_EXEC)
 $(LIBTBT_EXEC): $(O_FILES)
 	$(CC) $(CFLAGS) -o $@ $^ -lm
 
+install: $(LIBTBT_EXEC)
+	$(INSTALL) -d -m 755 $(DESTDIR)$(INSTALL_PATH)
+	$(INSTALL) $(LIBTBT_EXEC) $(DESTDIR)$(INSTALL_PATH)
+
+uninstall:
+	$(RM) $(DESTDIR)$(INSTALL_PATH)/$(LIBTBT_EXEC)
+
 clean:
 	-$(RM) $(LIBTBT_EXEC) $(O_FILES)
 
-.PHONY: all clean
+.PHONY: all clean install uninstall


### PR DESCRIPTION
Avoids trying to write into system directories during build. Respects `$DESTDIR` which should make it a little easier for distributions to build packages.

Fixes #1