### PR TITLE
build: resolve Permission Denied error during link

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@
 # Copyright (C) 2023 Rajat Khandelwal <rajat.khandelwal@intel.com>
 # Copyright (C) 2023 Intel Corporation
 
-LIBTBT_EXEC = /usr/bin/lstbt
+LIBTBT_EXEC = lstbt
 
 CC = gcc
 RM = rm -f
@@ -26,4 +26,3 @@ $(LIBTBT_EXEC): $(O_FILES)
 
 clean:
 	-$(RM) $(LIBTBT_EXEC) $(O_FILES)
-


### PR DESCRIPTION
gcc -g -Wall -W -O2 -o /usr/bin/lstbt lstbt.o lstbt_t.o lstbt_r.o lstbt_v.o router.o adapter.o helpers.o ../utils.o -lm /usr/lib64/gcc/x86_64-suse-linux/13/../../../../x86_64-suse-linux/bin/ld: cannot open output file /usr/bin/lstbt: Permission denied collect2: error: ld returned 1 exit status