### PR TITLE
Fix lstbt crash with Linux 6.3.9

### DIFF
--- a/lib/helpers.c
+++ b/lib/helpers.c
@@ -652,11 +652,14 @@ void dump_vdid(const char *router)
 
 	snprintf(did_path, sizeof(did_path), "cat %s%s/device", tbt_sysfs_path, router);
 	did = do_bash_cmd(did_path);
-
-	printf("ID %04x:%04x ", strtouh(vid), strtouh(did));
-
-	free(vid);
-	free(did);
+	if (vid != NULL && did != NULL)
+		printf("ID %04x:%04x ", strtouh(vid), strtouh(did));
+	else
+		printf("ID -- ");
+	if (vid != NULL)
+		free(vid);
+	if (did != NULL)
+		free(did);
 }
 
 /* Dump the generation of the router */

--- a/lib/helpers.h
+++ b/lib/helpers.h
@@ -76,3 +76,8 @@ int __main(char *domain, char *depth, char *device, bool retimer, bool tree,
 	   u8 verbose);
 char** ameliorate_args(int argc, char **argv);
 bool is_input_printable(int argc, char **argv);
+
+static inline const char *dnull(const char *s)
+{
+	return s != NULL ? s : "--";
+}

--- a/lib/lstbt.c
+++ b/lib/lstbt.c
@@ -40,10 +40,11 @@ static void dump_name(const char *router)
 	snprintf(d_path, sizeof(d_path), "cat %s%s/device_name", tbt_sysfs_path, router);
 	device = do_bash_cmd(d_path);
 
-	printf("%s %s ", vendor, device);
-
-	free(vendor);
-	free(device);
+	printf("%s %s ", dnull(vendor), dnull(device));
+	if (vendor != NULL)
+		free(vendor);
+	if (device != NULL)
+		free(device);
 }
 
 static bool dump_router(const char *router)

--- a/lib/lstbt_r.c
+++ b/lib/lstbt_r.c
@@ -78,9 +78,9 @@ static void dump_retimer_nvm_version(const char *retimer)
 		 retimer);
 
 	ver = do_bash_cmd(path);
-	printf("NVM %s\n", ver);
-
-	free(ver);
+	printf("NVM %s\n", dnull(ver));
+	if (ver != NULL)
+		free(ver);
 }
 
 /* Dumps the retimer */
@@ -124,12 +124,16 @@ static bool dump_retimer(const char *retimer)
 	snprintf(did_path, sizeof(did_path), "cat %s%s/device", tbt_sysfs_path, retimer);
 	did = do_bash_cmd(did_path);
 
-	printf("ID %04x:%04x ", strtouh(vid), strtouh(did));
+	if (vid != NULL && did != NULL)
+		printf("ID %04x:%04x ", strtouh(vid), strtouh(did));
+	else
+		printf("-- ");
 
 	dump_retimer_nvm_version(retimer);
-
-	free(vid);
-	free(did);
+	if (vid != NULL)
+		free(vid);
+	if (did != NULL)
+		free(did);
 	free(router);
 
 	return true;

--- a/lib/lstbt_v.c
+++ b/lib/lstbt_v.c
@@ -37,10 +37,11 @@ static void dump_name(const char *router)
 	snprintf(d_path, sizeof(d_path), "cat %s%s/device_name", tbt_sysfs_path, router);
 	device = do_bash_cmd(d_path);
 
-	printf("%s %s ", vendor, device);
-
-	free(vendor);
-	free(device);
+	printf("%s %s ", dnull(vendor), dnull(device));
+	if (vendor != NULL)
+		free(vendor);
+	if (device != NULL)
+		free(device);
 }
 
 static void dump_spaces(u64 spaces)


### PR DESCRIPTION
With Linux 6.3.9, I observed:

```
cat: /sys/bus/thunderbolt/devices/0-0/vendor: No such file or directory
cat: /sys/bus/thunderbolt/devices/0-0/device: No such file or directory
Segmentation fault (core dumped)
```